### PR TITLE
Fix for work on Logstash v5

### DIFF
--- a/lib/logstash/inputs/mqtt.rb
+++ b/lib/logstash/inputs/mqtt.rb
@@ -12,14 +12,14 @@ class LogStash::Inputs::Mqtt < LogStash::Inputs::Base
   config_name "mqtt"
 
   # The codec used for input data. Input codecs are a convenient method for decoding your data before it enters the input, without needing a separate filter in your Logstash pipeline.
-  default :codec, "plain" 
-  
+  default :codec, "plain"
+
   # The host of the MQTT broker
   config :mqttHost, :validate => :string, :default => "localhost"
-  
+
   # The port that the MQTT broker is using
   config :port, :validate => :number, :default => 1883
-  
+
   # Whether connection to the MQTT broker is using SSL or not.
   config :ssl, :validate => :boolean, :default => false
 
@@ -60,9 +60,12 @@ class LogStash::Inputs::Mqtt < LogStash::Inputs::Base
     @client.subscribe(@topic => @qos)
     @client.get do |topic,message|
         @codec.decode(message) do |event|
-            event["host"] ||= @host
-            event["topic"] = topic
+            host = event.get("host")
+            host ||= @host
+            host.set("host", host)
             
+            event.set("topic", topic)
+
             decorate(event)
             queue << event
         end

--- a/logstash-input-mqtt.gemspec
+++ b/logstash-input-mqtt.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-mqtt'
-  s.version = '0.0.1'
+  s.version = '0.0.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This input plugin subscribes to a mqtt topic and ."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
+  s.add_runtime_dependency "logstash-core", '>= 1.4.0'
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud'
   s.add_runtime_dependency 'mqtt'


### PR DESCRIPTION
Hi @widarlein , I'm using logstash-input-mqtt on my products.

I try to fix logstash-input-mqtt for working on Logstash v5.*.* . ( It's confirmed working on Logstash 5.4.0) 

Could you merge my PR, and publish upgraded gem ?

Thanks.